### PR TITLE
Shows "no filling" when cookie's filling has not been specified

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,3 +77,5 @@ group :test do
   gem 'rspec_junit_formatter'
   gem 'rails-controller-testing'
 end
+
+gem "byebug", "~> 11.1", :groups => [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
+    byebug (11.1.3)
     capybara (3.16.2)
       addressable
       mini_mime (>= 0.1.3)
@@ -295,6 +296,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   binding_of_caller
+  byebug (~> 11.1)
   capybara
   coffee-rails
   database_cleaner

--- a/app/helpers/ovens_helper.rb
+++ b/app/helpers/ovens_helper.rb
@@ -1,2 +1,6 @@
 module OvensHelper
+  def show_cookie_filling(cookie)
+    return "no fillings" if cookie.fillings.blank?
+    cookie.fillings
+  end
 end

--- a/app/views/ovens/show.html.haml
+++ b/app/views/ovens/show.html.haml
@@ -3,7 +3,7 @@
 .cookie-info
   Cookie in oven:
   - if @oven.cookie
-    1 cookie with #{@oven.cookie.fillings || "no fillings"}
+    1 cookie with #{show_cookie_filling(@oven.cookie)}
     - if @oven.cookie.ready?
       (Your Cookie is Ready)
       = button_to "Retrieve Cookie", empty_oven_path, class: 'button tiny'


### PR DESCRIPTION
- Adds show_cookie_filling(cookie) method to the Ovens view helper

Issue: #1